### PR TITLE
Delta core scott flink 00

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -729,13 +729,14 @@ def flinkScalaVersion(scalaBinaryVersion: String): String = {
 val flinkVersion = "1.15.3"
 lazy val flink = (project in file("flink"))
   .dependsOn(standaloneCosmetic % "provided")
+  .dependsOn(core % "compile->compile;test->test")
   .enablePlugins(GenJavadocPlugin, JavaUnidocPlugin)
   .settings (
     name := "delta-flink",
     commonSettings,
     releaseSettings,
     publishArtifact := scalaBinaryVersion.value == "2.12", // only publish once
-    autoScalaLibrary := false, // exclude scala-library from dependencies
+//    autoScalaLibrary := false, // exclude scala-library from dependencies
     Test / publishArtifact := false,
     pomExtra :=
       <url>https://github.com/delta-io/connectors</url>
@@ -757,6 +758,19 @@ lazy val flink = (project in file("flink"))
         </developers>,
     crossPaths := false,
     libraryDependencies ++= Seq(
+      // For delta-core
+      "org.apache.arrow" % "arrow-dataset" % "11.0.0",
+      "org.apache.arrow" % "arrow-memory-unsafe" % arrowVersion excludeAll (
+        ExclusionRule("com.fasterxml.jackson.core"),
+        ExclusionRule("com.fasterxml.jackson.module")
+      ),
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.4",
+      "org.json4s" %% "json4s-jackson" % "3.7.0-M11" excludeAll (
+        ExclusionRule("com.fasterxml.jackson.core"),
+        ExclusionRule("com.fasterxml.jackson.module")
+      ),
+
+      // Previous
       "org.apache.flink" % "flink-parquet" % flinkVersion % "provided",
       "org.apache.flink" % "flink-table-common" % flinkVersion % "provided",
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",

--- a/core/src/main/java/io/delta/standalone/core/DeltaScanTaskCore.java
+++ b/core/src/main/java/io/delta/standalone/core/DeltaScanTaskCore.java
@@ -1,8 +1,18 @@
 package io.delta.standalone.core;
 
+import java.io.Serializable;
+import java.util.Map;
+
 import io.delta.standalone.data.RowBatch;
+import io.delta.standalone.types.StructType;
 import io.delta.standalone.utils.CloseableIterator;
 
-public interface DeltaScanTaskCore {
+public interface DeltaScanTaskCore extends Serializable {
     CloseableIterator<RowBatch> getDataAsRows();
+
+    String getFilePath();
+
+    StructType getSchema();
+
+    Map<String, String> getPartitionValues();
 }

--- a/core/src/main/java/io/delta/standalone/core/DeltaScanTaskCore.java
+++ b/core/src/main/java/io/delta/standalone/core/DeltaScanTaskCore.java
@@ -15,4 +15,5 @@ public interface DeltaScanTaskCore extends Serializable {
     StructType getSchema();
 
     Map<String, String> getPartitionValues();
+
 }

--- a/core/src/main/java/io/delta/standalone/types/DataType.java
+++ b/core/src/main/java/io/delta/standalone/types/DataType.java
@@ -38,6 +38,7 @@
 
 package io.delta.standalone.types;
 
+import java.io.Serializable;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -47,7 +48,7 @@ import java.util.Objects;
  * <a href="https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala" target="_blank">DataType</a>,
  * allowing Spark SQL schemas to be represented in Java.
  */
-public abstract class DataType {
+public abstract class DataType implements Serializable {
     /**
      * Parses the input {@code json} into a {@link DataType}.
      *

--- a/core/src/main/java/io/delta/standalone/types/FieldMetadata.java
+++ b/core/src/main/java/io/delta/standalone/types/FieldMetadata.java
@@ -38,6 +38,7 @@
 
 package io.delta.standalone.types;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -47,7 +48,7 @@ import java.util.stream.Collectors;
 /**
  * The metadata for a given {@link StructField}.
  */
-public final class FieldMetadata {
+public final class FieldMetadata implements Serializable {
     private final Map<String, Object> metadata;
 
     private FieldMetadata(Map<String, Object> metadata) {

--- a/core/src/main/java/io/delta/standalone/types/StructField.java
+++ b/core/src/main/java/io/delta/standalone/types/StructField.java
@@ -38,12 +38,13 @@
 
 package io.delta.standalone.types;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * A field inside a {@link StructType}.
  */
-public final class StructField {
+public final class StructField implements Serializable {
     private final String name;
     private final DataType dataType;
     private final boolean nullable;

--- a/core/src/main/scala/io/delta/core/internal/ColumnarBatchRow.scala
+++ b/core/src/main/scala/io/delta/core/internal/ColumnarBatchRow.scala
@@ -6,9 +6,9 @@ import java.util
 import io.delta.standalone.data.{ColumnarRowBatch, ColumnVector, RowRecord}
 import io.delta.standalone.types.StructType
 
-
+// reference to a ROW in a table by using the index
 class ColumnarBatchRow(
-    columnarBatch: ColumnarRowBatch,
+    columnarBatch: ColumnarRowBatch, // the actual data in the table
     rowId: Int
   ) extends RowRecord {
   /**

--- a/core/src/main/scala/io/delta/core/internal/CombinedRowRecord.scala
+++ b/core/src/main/scala/io/delta/core/internal/CombinedRowRecord.scala
@@ -12,6 +12,7 @@ import io.delta.standalone.types._
  * @param schema          the intended schema for this record
  * @param partitionValues the deserialized partition values of current record
  */
+// scalastyle:off println
 case class CombinedRowRecord(
   innerRow: RowRecord,
   schema: StructType,
@@ -27,9 +28,11 @@ case class CombinedRowRecord(
   override def getLength: Int = innerRow.getLength + partitionValues.size
 
   override def isNullAt(fieldName: String): Boolean = {
+    println(s"Scott > CombinedRowRecord > isNullAt $fieldName")
     if (partitionValues.contains(fieldName)) { // is partition field
       partitionValues(fieldName) == null
     } else {
+      println(s"Scott > CombinedRowRecord > isNullAt >> calling innerRow")
       innerRow.isNullAt(fieldName)
     }
   }

--- a/core/src/main/scala/io/delta/core/internal/DeltaScanCoreImpl.scala
+++ b/core/src/main/scala/io/delta/core/internal/DeltaScanCoreImpl.scala
@@ -7,12 +7,14 @@ import io.delta.standalone.core.{DeltaScanCore, DeltaScanHelper, DeltaScanTaskCo
 import io.delta.standalone.data.RowRecord
 import io.delta.standalone.utils.CloseableIterator
 
+// scalastyle:off println
 class DeltaScanCoreImpl(
     snapshot: DeltaSnapshotCoreImpl,
     scanHelper: DeltaScanHelper)
   extends DeltaScanCore {
 
   def getTasks(): CloseableIterator[DeltaScanTaskCore] = {
+    println("Scott > DeltaScanCoreImpl > getTasks()")
     new CloseableIterator[DeltaScanTaskCore] {
       private val iter = replay.getAddFileIterator(_ => true)
 
@@ -20,6 +22,7 @@ class DeltaScanCoreImpl(
 
       override def next(): DeltaScanTaskCore = {
         val addFile = iter.next()
+        println("Scott > DeltaScanCoreImpl > next :: iter.next() " + addFile.getPath)
         println("Add file: " + addFile)
         new DeltaScanTaskCoreImpl(
           FileNames.absolutePath(snapshot.log.dataPath, addFile.getPath),

--- a/core/src/main/scala/io/delta/core/internal/DeltaScanTaskCoreImpl.scala
+++ b/core/src/main/scala/io/delta/core/internal/DeltaScanTaskCoreImpl.scala
@@ -1,10 +1,13 @@
 package io.delta.core.internal
 
+import java.util
 import java.util.TimeZone
+
+import scala.collection.JavaConverters._
 
 import io.delta.core.internal.utils.CloseableIteratorScala._
 import io.delta.standalone.core.{DeltaScanHelper, DeltaScanTaskCore}
-import io.delta.standalone.data.{RowRecord, RowBatch}
+import io.delta.standalone.data.{RowBatch, RowRecord}
 import io.delta.standalone.types._
 import io.delta.standalone.utils.CloseableIterator
 
@@ -15,7 +18,11 @@ class DeltaScanTaskCoreImpl(
     schema: StructType,
     readTimeZone: TimeZone,
     scanHelper: DeltaScanHelper) extends DeltaScanTaskCore {
+  override def getFilePath: String = filePath
 
+  override def getSchema: StructType = schema
+
+  override def getPartitionValues: util.Map[String, String] = filePartitionValues.asJava
 
   override def getDataAsRows(): CloseableIterator[RowBatch] = {
     var decodedPartitionValues: Map[String, Any] = Map()

--- a/core/src/main/scala/io/delta/core/internal/DeltaScanTaskCoreImpl.scala
+++ b/core/src/main/scala/io/delta/core/internal/DeltaScanTaskCoreImpl.scala
@@ -11,13 +11,14 @@ import io.delta.standalone.data.{RowBatch, RowRecord}
 import io.delta.standalone.types._
 import io.delta.standalone.utils.CloseableIterator
 
-
+// scalastyle:off println
 class DeltaScanTaskCoreImpl(
     filePath: String,
     filePartitionValues: Map[String, String],
     schema: StructType,
     readTimeZone: TimeZone,
     scanHelper: DeltaScanHelper) extends DeltaScanTaskCore {
+  println(s"Scott > created DeltaScanTaskCoreImpl $filePath \n${schema.getTreeString}")
   override def getFilePath: String = filePath
 
   override def getSchema: StructType = schema
@@ -25,6 +26,8 @@ class DeltaScanTaskCoreImpl(
   override def getPartitionValues: util.Map[String, String] = filePartitionValues.asJava
 
   override def getDataAsRows(): CloseableIterator[RowBatch] = {
+    println(s"Scott > DeltaScanTaskCoreImpl > getDataAsRows for $filePath")
+
     var decodedPartitionValues: Map[String, Any] = Map()
 
     if (null != filePartitionValues) {
@@ -48,6 +51,7 @@ class DeltaScanTaskCoreImpl(
         schema.getFields.filterNot(f => filePartitionValues.contains(f.getName))
       val iter = scanHelper.readParquetFile(
         filePath, new StructType(parquetReadFields), readTimeZone)
+      println(s"Scott > DeltaScanTaskCoreImpl > getDataAsRows > created parquetFileIter")
       override def hasNext: Boolean = iter.hasNext
       override def next(): RowBatch = {
         val extendedRows = iter.next().getRows.asScalaCloseable.mapAsCloseable(row =>

--- a/core/src/test/scala/io/delta/core/JsonRow.scala
+++ b/core/src/test/scala/io/delta/core/JsonRow.scala
@@ -55,7 +55,7 @@ class JsonRow(rootNode: ObjectNode) extends RowRecord {
     val keyValuePairs = objectNode.fields().asScala.map { entry =>
       entry.getKey -> getValue(entry.getValue)
     }
-    if (keyValuePairs.isEmpty) return util.Map.of[K, V]()
+    if (keyValuePairs.isEmpty) return Map.empty[K, V].asJava
     keyValuePairs.toMap.asJava.asInstanceOf[util.Map[K, V]]
   }
 

--- a/flink/src/main/java/io/delta/flink/source/internal/builder/RowDataFormat.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/builder/RowDataFormat.java
@@ -31,6 +31,8 @@ public class RowDataFormat implements DeltaBulkFormat<RowData> {
     public Reader<RowData> createReader(
             org.apache.flink.configuration.Configuration configuration,
             DeltaSourceSplit deltaSourceSplit) throws IOException {
+        System.out.println(
+            "Scott > RowDataFormat :: createReader, split " + deltaSourceSplit.path());
         return new DeltaCoreRowDataReader(deltaSourceSplit.deltaScanTaskCore);
 //        return this.decoratedInputFormat.createReader(configuration, deltaSourceSplit);
     }

--- a/flink/src/main/java/io/delta/flink/source/internal/builder/RowDataFormat.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/builder/RowDataFormat.java
@@ -2,8 +2,11 @@ package io.delta.flink.source.internal.builder;
 
 import java.io.IOException;
 
+import io.delta.flink.source.internal.core.DeltaCoreRowDataReader;
 import io.delta.flink.source.internal.state.DeltaSourceSplit;
+import javax.annotation.Nullable;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.formats.parquet.ParquetColumnarRowInputFormat;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
@@ -28,8 +31,8 @@ public class RowDataFormat implements DeltaBulkFormat<RowData> {
     public Reader<RowData> createReader(
             org.apache.flink.configuration.Configuration configuration,
             DeltaSourceSplit deltaSourceSplit) throws IOException {
-
-        return this.decoratedInputFormat.createReader(configuration, deltaSourceSplit);
+        return new DeltaCoreRowDataReader(deltaSourceSplit.deltaScanTaskCore);
+//        return this.decoratedInputFormat.createReader(configuration, deltaSourceSplit);
     }
 
     @Override

--- a/flink/src/main/java/io/delta/flink/source/internal/core/DeltaCoreRowDataReader.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/core/DeltaCoreRowDataReader.java
@@ -1,0 +1,72 @@
+package io.delta.flink.source.internal.core;
+
+import java.io.IOException;
+
+import io.delta.standalone.core.DeltaScanTaskCore;
+import io.delta.standalone.data.RowBatch;
+import io.delta.standalone.data.RowRecord;
+import io.delta.standalone.utils.CloseableIterator;
+import javax.annotation.Nullable;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.util.RecordAndPosition;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * The actual reader that reads the batches of records.
+ */
+public class DeltaCoreRowDataReader implements BulkFormat.Reader<RowData> {
+    private final DeltaScanTaskCore deltaScanTaskCore;
+    private final CloseableIterator<RowBatch> iter;
+
+    public DeltaCoreRowDataReader(DeltaScanTaskCore deltaScanTaskCore) {
+        this.deltaScanTaskCore = deltaScanTaskCore;
+        this.iter = deltaScanTaskCore.getDataAsRows();
+    }
+
+    /**
+     * Reads one batch. The method should return null when reaching the end of the input.
+     * The returned batch will be handed over to the processing threads as one.
+     */
+    @Nullable
+    @Override
+    public BulkFormat.RecordIterator<RowData> readBatch() throws IOException {
+        /**
+         * An iterator over records with their position in the file. The iterator is closeable to
+         * support clean resource release and recycling.
+         */
+        return new BulkFormat.RecordIterator<RowData>() {
+            private CloseableIterator<RowRecord> rowBatchRecordsIter = null;
+
+            @Nullable
+            @Override
+            public RecordAndPosition<RowData> next() {
+                if (rowBatchRecordsIter == null) {
+                    if (!iter.hasNext()) {
+                        return null;
+                    } else {
+                        final RowBatch rowBatch = iter.next();
+                        rowBatchRecordsIter = rowBatch.toRowIterator(); // TODO: synchronized ?
+                    }
+                }
+
+                if (!rowBatchRecordsIter.hasNext()) return null;
+
+                RowRecord rowRecord = rowBatchRecordsIter.next();
+
+                RowData rowData = new RowRecordToRowData(rowRecord, deltaScanTaskCore.getSchema());
+
+                return new RecordAndPosition<>(rowData, 0L /* offset */, 0L /* recordSkipCount */);
+            }
+
+            @Override
+            public void releaseBatch() {
+
+            }
+        };
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+}

--- a/flink/src/main/java/io/delta/flink/source/internal/core/DeltaCoreRowDataReader.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/core/DeltaCoreRowDataReader.java
@@ -20,32 +20,38 @@ import static org.apache.flink.connector.file.src.util.RecordAndPosition.NO_OFFS
  */
 public class DeltaCoreRowDataReader implements BulkFormat.Reader<RowData> {
     private final DeltaScanTaskCore deltaScanTaskCore;
-    private final CloseableIterator<RowBatch> rowBatchIter;
+    private final CloseableIterator<RowBatch> rowBatchIter; // ITERATOR of ITERATOR of ROWS
 
     public DeltaCoreRowDataReader(DeltaScanTaskCore deltaScanTaskCore) {
         System.out.println("Created DeltaCoreRowDataReader >> " + deltaScanTaskCore);
         this.deltaScanTaskCore = deltaScanTaskCore;
-        this.rowBatchIter = deltaScanTaskCore == null ? null : deltaScanTaskCore.getDataAsRows();
+        this.rowBatchIter = deltaScanTaskCore.getDataAsRows();
     }
 
     /**
      * Reads one batch. The method should return null when reaching the end of the input.
      * The returned batch will be handed over to the processing threads as one.
+     *
+     * To implement reuse and to save object allocation, consider using a
+     * org.apache.flink.connector.file.src.util.Pool and recycle objects into the Pool in the the
+     * BulkFormat.RecordIterator.releaseBatch() method
      */
     @Nullable
     @Override
     public BulkFormat.RecordIterator<RowData> readBatch() throws IOException {
-        System.out.println("Scott > DeltaCoreRowDataReader > readBatch");
+        if (!rowBatchIter.hasNext()) {
+            System.out.println("Scott > DeltaCoreRowDataReader > readBatch RETURNING NULL");
+            return null;
+        }
+
+        System.out.println("Scott > DeltaCoreRowDataReader > readBatch RETURNING NEW ITERATOR");
+
         /**
          * An iterator over records with their position in the file. The iterator is closeable to
          * support clean resource release and recycling.
          */
         return new BulkFormat.RecordIterator<RowData>() {
-            {
-                System.out.println("Scott > created new BulkFormat.RecordIterator<RowData>()");
-            }
-            private CloseableIterator<RowRecord> rowBatchRecordsIter = null;
-            private int hashCode = -1; // helpful for debugging
+            private CloseableIterator<RowRecord> recordsIterForCurrentRowBatch = null;
             private long numRecords = 0;
 
             /**
@@ -65,41 +71,21 @@ public class DeltaCoreRowDataReader implements BulkFormat.Reader<RowData> {
             @Nullable
             @Override
             public RecordAndPosition<RowData> next() {
-                if (rowBatchIter == null) {
-                    System.out.println("Scott > DeltaCoreRowDataReader > next :: iter is NULL");
+                if (recordsIterForCurrentRowBatch == null) {
+                    final RowBatch rowBatch = rowBatchIter.next();
+                    System.out.println("Scott > DeltaCoreRowDataReader > BulkFormat.RecordIterator<RowData> > next :: rowBatchIter.next()");
+                    recordsIterForCurrentRowBatch = rowBatch.toRowIterator();
+                }
+
+                if (!recordsIterForCurrentRowBatch.hasNext()) {
+                    System.out.println("Scott > DeltaCoreRowDataReader > recordsIterForCurrentRowBatch has no next");
                     return null;
                 }
-                if (rowBatchRecordsIter == null) {
-                    if (!rowBatchIter.hasNext()) {
-                        System.out.println("Scott > DeltaCoreRowDataReader > rowBatchIter no next");
-                        return null;
-                    } else {
-                        final RowBatch rowBatch = rowBatchIter.next();
-                        System.out.println("Scott > DeltaCoreRowDataReader > called ITER.NEXT()");
-                        System.out.println("Scott > DeltaCoreRowDataReader > rowBatch " + rowBatch);
-                        rowBatchRecordsIter = rowBatch.toRowIterator(); // TODO: synchronized ?
-                        System.out.println("Scott > DeltaCoreRowDataReader > rowBatchRecordsIter " +
-                            rowBatchRecordsIter);
-                        hashCode = rowBatchRecordsIter.hashCode() % 1000;
-                        System.out.println("Scott > DeltaCoreRowDataReader > hashCode " + hashCode);
-                    }
-                }
 
-                if (!rowBatchRecordsIter.hasNext()) {
-                    System.out.println("Scott > DeltaCoreRowDataReader > rowBatchRecordsIter no " +
-                        "next");
-                    rowBatchRecordsIter = null;
-                    // go to the next
-                    return next();
-                }
-
-                RowRecord rowRecord = rowBatchRecordsIter.next();
-                System.out.println(hashCode + " - Scott > DeltaCoreRowDataReader > rowRecord " +
-                    rowRecord);
+                System.out.println("Scott > DeltaCoreRowDataReader > recordsIterForCurrentRowBatch has next");
+                RowRecord rowRecord = recordsIterForCurrentRowBatch.next();
                 RowData rowData = new RowRecordToRowData(rowRecord, deltaScanTaskCore.getSchema());
                 numRecords++;
-                System.out.println(hashCode + " - Scott > DeltaCoreRowDataReader > numRecords " +
-                    numRecords);
 
                 // TODO: MutableRecordAndPosition
                 return new RecordAndPosition<>(rowData, NO_OFFSET /* offset */, numRecords /* recordSkipCount */);
@@ -107,7 +93,7 @@ public class DeltaCoreRowDataReader implements BulkFormat.Reader<RowData> {
 
             @Override
             public void releaseBatch() {
-
+                System.out.println("Scott > DeltaCoreRowDataReader > releaseBatch");
             }
         };
     }

--- a/flink/src/main/java/io/delta/flink/source/internal/core/DeltaCoreRowDataReader.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/core/DeltaCoreRowDataReader.java
@@ -11,16 +11,21 @@ import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.src.util.RecordAndPosition;
 import org.apache.flink.table.data.RowData;
 
+import static org.apache.flink.connector.file.src.util.RecordAndPosition.NO_OFFSET;
+
 /**
  * The actual reader that reads the batches of records.
+ *
+ * TODO something is very wrong here
  */
 public class DeltaCoreRowDataReader implements BulkFormat.Reader<RowData> {
     private final DeltaScanTaskCore deltaScanTaskCore;
-    private final CloseableIterator<RowBatch> iter;
+    private final CloseableIterator<RowBatch> rowBatchIter;
 
     public DeltaCoreRowDataReader(DeltaScanTaskCore deltaScanTaskCore) {
+        System.out.println("Created DeltaCoreRowDataReader >> " + deltaScanTaskCore);
         this.deltaScanTaskCore = deltaScanTaskCore;
-        this.iter = deltaScanTaskCore.getDataAsRows();
+        this.rowBatchIter = deltaScanTaskCore == null ? null : deltaScanTaskCore.getDataAsRows();
     }
 
     /**
@@ -30,32 +35,74 @@ public class DeltaCoreRowDataReader implements BulkFormat.Reader<RowData> {
     @Nullable
     @Override
     public BulkFormat.RecordIterator<RowData> readBatch() throws IOException {
+        System.out.println("Scott > DeltaCoreRowDataReader > readBatch");
         /**
          * An iterator over records with their position in the file. The iterator is closeable to
          * support clean resource release and recycling.
          */
         return new BulkFormat.RecordIterator<RowData>() {
+            {
+                System.out.println("Scott > created new BulkFormat.RecordIterator<RowData>()");
+            }
             private CloseableIterator<RowRecord> rowBatchRecordsIter = null;
+            private int hashCode = -1; // helpful for debugging
+            private long numRecords = 0;
 
+            /**
+             * Gets the next record from the file, together with its position.
+             * The position information returned with the record point to the record AFTER the
+             * returned record, because it defines the point where the reading should resume once
+             * the current record is emitted. The position information is put in the source's state
+             * when the record is emitted. If a checkpoint is taken directly after the record is
+             * emitted, the checkpoint must to describe where to resume the source reading from
+             * after that record.
+             *
+             * Objects returned by this method may be reused by the iterator. By the time that this
+             * method is called again, no object returned from the previous call will be referenced
+             * any more. That makes it possible to have a single MutableRecordAndPosition object and
+             * return the same instance (with updated record and position) on every call.
+             */
             @Nullable
             @Override
             public RecordAndPosition<RowData> next() {
+                if (rowBatchIter == null) {
+                    System.out.println("Scott > DeltaCoreRowDataReader > next :: iter is NULL");
+                    return null;
+                }
                 if (rowBatchRecordsIter == null) {
-                    if (!iter.hasNext()) {
+                    if (!rowBatchIter.hasNext()) {
+                        System.out.println("Scott > DeltaCoreRowDataReader > rowBatchIter no next");
                         return null;
                     } else {
-                        final RowBatch rowBatch = iter.next();
+                        final RowBatch rowBatch = rowBatchIter.next();
+                        System.out.println("Scott > DeltaCoreRowDataReader > called ITER.NEXT()");
+                        System.out.println("Scott > DeltaCoreRowDataReader > rowBatch " + rowBatch);
                         rowBatchRecordsIter = rowBatch.toRowIterator(); // TODO: synchronized ?
+                        System.out.println("Scott > DeltaCoreRowDataReader > rowBatchRecordsIter " +
+                            rowBatchRecordsIter);
+                        hashCode = rowBatchRecordsIter.hashCode() % 1000;
+                        System.out.println("Scott > DeltaCoreRowDataReader > hashCode " + hashCode);
                     }
                 }
 
-                if (!rowBatchRecordsIter.hasNext()) return null;
+                if (!rowBatchRecordsIter.hasNext()) {
+                    System.out.println("Scott > DeltaCoreRowDataReader > rowBatchRecordsIter no " +
+                        "next");
+                    rowBatchRecordsIter = null;
+                    // go to the next
+                    return next();
+                }
 
                 RowRecord rowRecord = rowBatchRecordsIter.next();
-
+                System.out.println(hashCode + " - Scott > DeltaCoreRowDataReader > rowRecord " +
+                    rowRecord);
                 RowData rowData = new RowRecordToRowData(rowRecord, deltaScanTaskCore.getSchema());
+                numRecords++;
+                System.out.println(hashCode + " - Scott > DeltaCoreRowDataReader > numRecords " +
+                    numRecords);
 
-                return new RecordAndPosition<>(rowData, 0L /* offset */, 0L /* recordSkipCount */);
+                // TODO: MutableRecordAndPosition
+                return new RecordAndPosition<>(rowData, NO_OFFSET /* offset */, numRecords /* recordSkipCount */);
             }
 
             @Override

--- a/flink/src/main/java/io/delta/flink/source/internal/core/DeltaCoreRowDataReader.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/core/DeltaCoreRowDataReader.java
@@ -82,13 +82,13 @@ public class DeltaCoreRowDataReader implements BulkFormat.Reader<RowData> {
                     return null;
                 }
 
-                System.out.println("Scott > DeltaCoreRowDataReader > recordsIterForCurrentRowBatch has next");
                 RowRecord rowRecord = recordsIterForCurrentRowBatch.next();
+                System.out.println("Scott > DeltaCoreRowDataReader > recordsIterForCurrentRowBatch has next " + rowRecord);
                 RowData rowData = new RowRecordToRowData(rowRecord, deltaScanTaskCore.getSchema());
                 numRecords++;
 
                 // TODO: MutableRecordAndPosition
-                return new RecordAndPosition<>(rowData, NO_OFFSET /* offset */, numRecords /* recordSkipCount */);
+                return new RecordAndPosition<>(rowData, NO_OFFSET /* offset */, numRecords + 1/* recordSkipCount */);
             }
 
             @Override

--- a/flink/src/main/java/io/delta/flink/source/internal/core/RowRecordToRowData.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/core/RowRecordToRowData.java
@@ -1,8 +1,11 @@
 package io.delta.flink.source.internal.core;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 
 import io.delta.standalone.data.RowRecord;
+import io.delta.standalone.types.DataType;
+import io.delta.standalone.types.LongType;
 import io.delta.standalone.types.StructField;
 import io.delta.standalone.types.StructType;
 import org.apache.commons.lang.NotImplementedException;
@@ -11,28 +14,36 @@ import org.apache.flink.types.RowKind;
 
 import static org.apache.flink.types.RowKind.INSERT;
 
-public class RowRecordToRowData implements RowData {
+public class RowRecordToRowData implements RowData, Serializable {
 
     private RowKind rowKind;
-    private final RowRecord impl;
     private final StructField[] schemaFields;
+    private final long hash;
+
+    // map idx -> Object
+    // for each field in schemaFields, get its data type, call impl.get$DataTYpe, store in a map
+    // no longer have a reference to the impl
+    private final Object[] values;
 
     public RowRecordToRowData(RowRecord impl, StructType schema) {
-        this.impl = impl;
         this.schemaFields = schema.getFields();
         this.rowKind = INSERT;
-    }
+        this.values = new Object[schemaFields.length];
+        this.hash = hashCode() % 10000;
+        System.out.println("Trying to create RowRecordToRowData " + this.hash);
+        for (int i = 0; i < schemaFields.length; i++) {
+            StructField field = schemaFields[i];
+            DataType dataType = field.getDataType();
 
-    private String posToFieldName(int pos) {
-        System.out.println(
-            String.format("Scott > RowRecordToRowData > posToFieldName pos %s length %s", pos, schemaFields.length)
-        );
-        if (pos >= schemaFields.length) {
-            throw new RuntimeException(
-                String.format("Index %s is out of bounds. Schema length: %s", pos, schemaFields.length)
-            );
+            if (dataType instanceof LongType) {
+                values[i] = impl.getLong(field.getName());
+                System.out.println(String.format("[RowRecordToRowData -- " + hash + "] -- Scott > Setting %s -> %s", i, values[i]));
+                System.out.println("created RowRecordToRowData " + this.hash + "--->" + values[i]);
+            } else {
+                throw new UnsupportedOperationException("We only support LongType");
+            }
         }
-        return schemaFields[pos].getName();
+        impl = null;
     }
 
     /**
@@ -58,68 +69,68 @@ public class RowRecordToRowData implements RowData {
 
     @Override
     public boolean isNullAt(int pos) {
-        return impl.isNullAt(posToFieldName(pos));
+        return values[pos] == null;
     }
 
     @Override
     public boolean getBoolean(int pos) {
-        return impl.getBoolean(posToFieldName(pos));
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public byte getByte(int pos) {
-        return impl.getByte(posToFieldName(pos));
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public short getShort(int pos) {
-        return impl.getShort(posToFieldName(pos));
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public int getInt(int pos) {
-        return impl.getInt(posToFieldName(pos));
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public long getLong(int pos) {
-        return impl.getLong(posToFieldName(pos));
+        System.out.println("[" + this.hash + "] -- getLong --" + (long) values[pos]);
+        return (long) values[pos];
     }
 
     @Override
     public float getFloat(int pos) {
-        return impl.getFloat(posToFieldName(pos));
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public double getDouble(int pos) {
-        return impl.getDouble(posToFieldName(pos));
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public StringData getString(int pos) {
-        return StringData.fromString(impl.getString(posToFieldName(pos)));
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public DecimalData getDecimal(int pos, int precision, int scale) {
-        final BigDecimal bigDecimal = impl.getBigDecimal(posToFieldName(pos));
-        return DecimalData.fromBigDecimal(bigDecimal, bigDecimal.precision(), bigDecimal.scale());
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public TimestampData getTimestamp(int pos, int precision) {
-        return TimestampData.fromTimestamp(impl.getTimestamp(posToFieldName(pos)));
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public <T> RawValueData<T> getRawValue(int pos) {
-        throw new NotImplementedException("getRawValue isn't implemented yet");
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public byte[] getBinary(int pos) {
-        return impl.getBinary(posToFieldName(pos));
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -134,7 +145,6 @@ public class RowRecordToRowData implements RowData {
 
     @Override
     public RowData getRow(int pos, int numFields) {
-        final RowRecord innerRow = impl.getRecord(posToFieldName(pos));
-        return new RowRecordToRowData(innerRow, innerRow.getSchema());
+        throw new UnsupportedOperationException();
     }
 }

--- a/flink/src/main/java/io/delta/flink/source/internal/core/RowRecordToRowData.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/core/RowRecordToRowData.java
@@ -24,6 +24,9 @@ public class RowRecordToRowData implements RowData {
     }
 
     private String posToFieldName(int pos) {
+        System.out.println(
+            String.format("Scott > RowRecordToRowData > posToFieldName pos %s length %s", pos, schemaFields.length)
+        );
         if (pos >= schemaFields.length) {
             throw new RuntimeException(
                 String.format("Index %s is out of bounds. Schema length: %s", pos, schemaFields.length)

--- a/flink/src/main/java/io/delta/flink/source/internal/core/RowRecordToRowData.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/core/RowRecordToRowData.java
@@ -1,0 +1,137 @@
+package io.delta.flink.source.internal.core;
+
+import java.math.BigDecimal;
+
+import io.delta.standalone.data.RowRecord;
+import io.delta.standalone.types.StructField;
+import io.delta.standalone.types.StructType;
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.flink.table.data.*;
+import org.apache.flink.types.RowKind;
+
+import static org.apache.flink.types.RowKind.INSERT;
+
+public class RowRecordToRowData implements RowData {
+
+    private RowKind rowKind;
+    private final RowRecord impl;
+    private final StructField[] schemaFields;
+
+    public RowRecordToRowData(RowRecord impl, StructType schema) {
+        this.impl = impl;
+        this.schemaFields = schema.getFields();
+        this.rowKind = INSERT;
+    }
+
+    private String posToFieldName(int pos) {
+        if (pos >= schemaFields.length) {
+            throw new RuntimeException(
+                String.format("Index %s is out of bounds. Schema length: %s", pos, schemaFields.length)
+            );
+        }
+        return schemaFields[pos].getName();
+    }
+
+    /**
+     * Returns the number of fields in this row.
+     */
+    @Override
+    public int getArity() {
+        return schemaFields.length;
+    }
+
+    /**
+     * Returns the kind of change that this row describes in a changelog.
+     */
+    @Override
+    public RowKind getRowKind() {
+        return rowKind;
+    }
+
+    @Override
+    public void setRowKind(RowKind kind) {
+        this.rowKind = kind;
+    }
+
+    @Override
+    public boolean isNullAt(int pos) {
+        return impl.isNullAt(posToFieldName(pos));
+    }
+
+    @Override
+    public boolean getBoolean(int pos) {
+        return impl.getBoolean(posToFieldName(pos));
+    }
+
+    @Override
+    public byte getByte(int pos) {
+        return impl.getByte(posToFieldName(pos));
+    }
+
+    @Override
+    public short getShort(int pos) {
+        return impl.getShort(posToFieldName(pos));
+    }
+
+    @Override
+    public int getInt(int pos) {
+        return impl.getInt(posToFieldName(pos));
+    }
+
+    @Override
+    public long getLong(int pos) {
+        return impl.getLong(posToFieldName(pos));
+    }
+
+    @Override
+    public float getFloat(int pos) {
+        return impl.getFloat(posToFieldName(pos));
+    }
+
+    @Override
+    public double getDouble(int pos) {
+        return impl.getDouble(posToFieldName(pos));
+    }
+
+    @Override
+    public StringData getString(int pos) {
+        return StringData.fromString(impl.getString(posToFieldName(pos)));
+    }
+
+    @Override
+    public DecimalData getDecimal(int pos, int precision, int scale) {
+        final BigDecimal bigDecimal = impl.getBigDecimal(posToFieldName(pos));
+        return DecimalData.fromBigDecimal(bigDecimal, bigDecimal.precision(), bigDecimal.scale());
+    }
+
+    @Override
+    public TimestampData getTimestamp(int pos, int precision) {
+        return TimestampData.fromTimestamp(impl.getTimestamp(posToFieldName(pos)));
+    }
+
+    @Override
+    public <T> RawValueData<T> getRawValue(int pos) {
+        throw new NotImplementedException("getRawValue isn't implemented yet");
+    }
+
+    @Override
+    public byte[] getBinary(int pos) {
+        return impl.getBinary(posToFieldName(pos));
+    }
+
+    @Override
+    public ArrayData getArray(int pos) {
+        throw new NotImplementedException("getArray isn't implemented yet");
+    }
+
+    @Override
+    public MapData getMap(int pos) {
+        throw new NotImplementedException("getMap isn't implemented yet");
+    }
+
+    @Override
+    public RowData getRow(int pos, int numFields) {
+        final RowRecord innerRow = impl.getRecord(posToFieldName(pos));
+        return new RowRecordToRowData(innerRow, innerRow.getSchema());
+    }
+}

--- a/flink/src/main/java/io/delta/flink/source/internal/enumerator/BoundedSplitEnumeratorProvider.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/enumerator/BoundedSplitEnumeratorProvider.java
@@ -55,11 +55,11 @@ public class BoundedSplitEnumeratorProvider implements SplitEnumeratorProvider {
             SplitEnumeratorContext<DeltaSourceSplit> enumContext,
             DeltaConnectorConfiguration sourceConfiguration) {
 
-        final String logPath = SourceUtils.pathToString(deltaTablePath) + "/_delta_log";
-        final LogReplayHelper logReplayHelper = new SimpleLogReplayHelper(configuration);
-
-        DeltaLogCore deltaLogCore = new DeltaLogCoreImpl(logPath, logReplayHelper);
-        DeltaSnapshotCore deltaSnapshotCore = deltaLogCore.getLatestSnapshot();
+//        final String logPath = SourceUtils.pathToString(deltaTablePath) + "/_delta_log";
+//        final LogReplayHelper logReplayHelper = new SimpleLogReplayHelper(configuration);
+//
+//        DeltaLogCore deltaLogCore = new DeltaLogCoreImpl(logPath, logReplayHelper);
+//        DeltaSnapshotCore deltaSnapshotCore = deltaLogCore.getLatestSnapshot();
 
         DeltaLog deltaLog =
             DeltaLog.forTable(configuration, SourceUtils.pathToString(deltaTablePath));
@@ -72,7 +72,7 @@ public class BoundedSplitEnumeratorProvider implements SplitEnumeratorProvider {
 
         SnapshotProcessor snapshotProcessor =
             new SnapshotProcessor(deltaTablePath, initSnapshot,
-                fileEnumeratorProvider.create(), Collections.emptySet(), deltaSnapshotCore, configuration);
+                fileEnumeratorProvider.create(), Collections.emptySet(), null /* deltaSnapshotCore */, configuration);
 
         return new BoundedDeltaSourceSplitEnumerator(
             deltaTablePath, snapshotProcessor, splitAssignerProvider.create(emptyList()),

--- a/flink/src/main/java/io/delta/flink/source/internal/enumerator/processor/SnapshotProcessor.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/enumerator/processor/SnapshotProcessor.java
@@ -1,24 +1,35 @@
 package io.delta.flink.source.internal.enumerator.processor;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
+import java.io.IOException;
+import java.util.*;
 import java.util.function.Consumer;
 
+import io.delta.core.SimpleScanHelper;
+import io.delta.flink.sink.internal.committer.DeltaCommitter;
 import io.delta.flink.source.internal.enumerator.monitor.ChangesPerVersion;
 import io.delta.flink.source.internal.file.AddFileEnumerator;
 import io.delta.flink.source.internal.state.DeltaEnumeratorStateCheckpointBuilder;
 import io.delta.flink.source.internal.state.DeltaSourceSplit;
 import io.delta.flink.source.internal.utils.SourceUtils;
+import io.delta.standalone.core.DeltaScanCore;
+import io.delta.standalone.core.DeltaScanHelper;
+import io.delta.standalone.core.DeltaScanTaskCore;
+import io.delta.standalone.core.DeltaSnapshotCore;
+import io.delta.standalone.utils.CloseableIterator;
 import org.apache.flink.core.fs.Path;
 
 import io.delta.standalone.Snapshot;
 import io.delta.standalone.actions.AddFile;
+import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This implementation of {@link TableProcessor} process data from Delta table {@link Snapshot}.
  */
 public class SnapshotProcessor extends TableProcessorBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SnapshotProcessor.class);
 
     /**
      * A {@link Snapshot} that is processed by this processor.
@@ -34,12 +45,37 @@ public class SnapshotProcessor extends TableProcessorBase {
      */
     private final HashSet<Path> alreadyProcessedPaths;
 
-    public SnapshotProcessor(Path deltaTablePath, Snapshot snapshot,
-        AddFileEnumerator<DeltaSourceSplit> fileEnumerator,
-        Collection<Path> alreadyProcessedPaths) {
+    private final DeltaSnapshotCore deltaSnapshotCore;
+
+    private final DeltaScanHelper deltaScanHelper;
+
+    public SnapshotProcessor(
+            Path deltaTablePath,
+            Snapshot snapshot,
+            AddFileEnumerator<DeltaSourceSplit> fileEnumerator,
+            Collection<Path> alreadyProcessedPaths) {
         super(deltaTablePath, fileEnumerator);
         this.snapshot = snapshot;
         this.alreadyProcessedPaths = new HashSet<>(alreadyProcessedPaths);
+        this.deltaSnapshotCore = null;
+        this.deltaScanHelper = null;
+        throw new RuntimeException("Scott > SnapshotProcessor > not using deltaSnapshotCore");
+    }
+
+    public SnapshotProcessor(
+            Path deltaTablePath,
+            Snapshot snapshot,
+            AddFileEnumerator<DeltaSourceSplit> fileEnumerator,
+            Collection<Path> alreadyProcessedPaths,
+            DeltaSnapshotCore deltaSnapshotCore,
+            Configuration hadoopConf) {
+        super(deltaTablePath, fileEnumerator);
+        this.snapshot = snapshot;
+        this.alreadyProcessedPaths = new HashSet<>(alreadyProcessedPaths);
+
+        LOG.info("Scott > SnapshotProcessor > using deltaSnapshotCore");
+        this.deltaScanHelper = new SimpleScanHelper(hadoopConf);
+        this.deltaSnapshotCore = deltaSnapshotCore;
     }
 
     /**
@@ -51,15 +87,37 @@ public class SnapshotProcessor extends TableProcessorBase {
      */
     @Override
     public void process(Consumer<List<DeltaSourceSplit>> processCallback) {
+        final DeltaScanCore deltaScanCore = deltaSnapshotCore.scan(deltaScanHelper);
+        final List<DeltaSourceSplit> splits = new ArrayList<>();
+
+        try (CloseableIterator<DeltaScanTaskCore> iter = deltaScanCore.getTasks()) {
+            final DeltaScanTaskCore task = iter.next();
+            LOG.info("Scott > SnapshotProcessor > created task for path {}", task.getFilePath());
+            final Path filePath = new Path(task.getFilePath());
+            final DeltaSourceSplit split = new DeltaSourceSplit(
+                task.getPartitionValues(), // partitionValues
+                UUID.randomUUID().toString(), // id
+                filePath, // filePath
+                0L, // offset
+                0L, // length
+                task);
+            splits.add(split);
+            alreadyProcessedPaths.add(filePath);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+
         // TODO Initial data read. This should be done in chunks since snapshot.getAllFiles()
         //  can have millions of files, and we would OOM the Job Manager
         //  if we would read all of them at once.
-        List<DeltaSourceSplit> splits =
-            prepareSplits(new ChangesPerVersion<>(
-                    SourceUtils.pathToString(deltaTablePath),
-                    snapshot.getVersion(),
-                    snapshot.getAllFiles()),
-                alreadyProcessedPaths::add);
+//        List<DeltaSourceSplit> splits =
+//            prepareSplits(new ChangesPerVersion<>(
+//                    SourceUtils.pathToString(deltaTablePath),
+//                    snapshot.getVersion(),
+//                    snapshot.getAllFiles()),
+//                alreadyProcessedPaths::add);
+
         processCallback.accept(splits);
     }
 

--- a/flink/src/main/java/io/delta/flink/source/internal/state/DeltaSourceSplit.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/state/DeltaSourceSplit.java
@@ -98,10 +98,27 @@ public class DeltaSourceSplit extends FileSourceSplit {
         CheckpointedPosition readerPosition) {
         super(id, filePath, offset, length, hostnames, readerPosition);
 
+        System.out.println("Scott > DeltaSourceSplit > Constructor2 :: created split for path " +
+            filePath.toString() + " but no scanTaskCore");
+
         // Make split Partition a new Copy of original map to for immutability.
         this.partitionValues =
             (partitionValues == null) ? Collections.emptyMap() : new HashMap<>(partitionValues);
         this.deltaScanTaskCore = null;
+    }
+
+    public DeltaSourceSplit(Map<String, String> partitionValues, String id,
+                            Path filePath, long offset, long length, String[] hostnames,
+                            CheckpointedPosition readerPosition, DeltaScanTaskCore deltaScanTaskCore) {
+        super(id, filePath, offset, length, hostnames, readerPosition);
+
+        System.out.println("Scott > DeltaSourceSplit > Constructor3 :: created split for path " +
+            filePath.toString());
+
+        // Make split Partition a new Copy of original map to for immutability.
+        this.partitionValues =
+            (partitionValues == null) ? Collections.emptyMap() : new HashMap<>(partitionValues);
+        this.deltaScanTaskCore = deltaScanTaskCore;
     }
 
     public DeltaSourceSplit(
@@ -113,6 +130,7 @@ public class DeltaSourceSplit extends FileSourceSplit {
         DeltaScanTaskCore deltaScanTaskCore
     ) {
         super(id, filePath, offset, length, NO_HOSTS, null);
+        System.out.println("Scott > DeltaSourceSplit > Constructor :: created split for path " + filePath.toString());
 
         // Make split Partition a new Copy of original map to for immutability.
         this.partitionValues =
@@ -123,8 +141,9 @@ public class DeltaSourceSplit extends FileSourceSplit {
 
     @Override
     public DeltaSourceSplit updateWithCheckpointedPosition(CheckpointedPosition position) {
+        System.out.println("DeltaSourceSplit > updateWithCheckpointedPosition");
         return new DeltaSourceSplit(partitionValues, splitId(), path(), offset(), length(),
-            hostnames(), position);
+            hostnames(), position, this.deltaScanTaskCore);
     }
 
     /**

--- a/flink/src/main/java/io/delta/flink/source/internal/state/DeltaSourceSplit.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/state/DeltaSourceSplit.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.delta.standalone.core.DeltaScanTaskCore;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.util.CheckpointedPosition;
@@ -29,6 +30,8 @@ import org.apache.flink.util.StringUtils;
 public class DeltaSourceSplit extends FileSourceSplit {
 
     private static final String[] NO_HOSTS = StringUtils.EMPTY_STRING_ARRAY;
+
+    public final DeltaScanTaskCore deltaScanTaskCore;
 
     /**
      * Map containing partition column name to partition column value mappings. This mapping is used
@@ -98,6 +101,24 @@ public class DeltaSourceSplit extends FileSourceSplit {
         // Make split Partition a new Copy of original map to for immutability.
         this.partitionValues =
             (partitionValues == null) ? Collections.emptyMap() : new HashMap<>(partitionValues);
+        this.deltaScanTaskCore = null;
+    }
+
+    public DeltaSourceSplit(
+        Map<String, String> partitionValues,
+        String id,
+        Path filePath,
+        long offset,
+        long length,
+        DeltaScanTaskCore deltaScanTaskCore
+    ) {
+        super(id, filePath, offset, length, NO_HOSTS, null);
+
+        // Make split Partition a new Copy of original map to for immutability.
+        this.partitionValues =
+            (partitionValues == null) ? Collections.emptyMap() : new HashMap<>(partitionValues);
+
+        this.deltaScanTaskCore = deltaScanTaskCore;
     }
 
     @Override

--- a/flink/src/main/java/io/delta/flink/source/internal/state/DeltaSourceSplitSerializer.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/state/DeltaSourceSplitSerializer.java
@@ -1,10 +1,10 @@
 package io.delta.flink.source.internal.state;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.util.Map;
 
+import io.delta.core.internal.DeltaScanTaskCoreImpl;
+import io.delta.standalone.core.DeltaScanTaskCore;
 import org.apache.flink.api.common.typeutils.base.MapSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.connector.source.SourceReader;
@@ -106,7 +106,20 @@ public final class DeltaSourceSplitSerializer
                 FileSourceSplitSerializer.INSTANCE.getVersion(), superBytes);
 
         Map<String, String> partitionValues = partitionSerDe.deserialize(inputWrapper);
+        ObjectInputStream in = new ObjectInputStream(inputWrapper);
 
+        DeltaScanTaskCore scanTaskCore;
+        try {
+            scanTaskCore = (DeltaScanTaskCoreImpl) in.readObject();
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Scott > failed to deserialize scanTaskScore", e);
+        }
+
+        System.out.println("Scott > DeltaSourceSplitSerializer > deserializeV1");
+//        ObjectInputStream in = new ObjectInputStream(fileIn);
+//        e = (Employee) in.readObject();
+//        DeltaScanTaskCore scanTaskCore =
         return new DeltaSourceSplit(
             partitionValues,
             superSplit.splitId(),
@@ -114,7 +127,8 @@ public final class DeltaSourceSplitSerializer
             superSplit.offset(),
             superSplit.length(),
             superSplit.hostnames(),
-            superSplit.getReaderPosition().orElse(null)
+            superSplit.getReaderPosition().orElse(null),
+            scanTaskCore
         );
     }
 
@@ -134,5 +148,11 @@ public final class DeltaSourceSplitSerializer
         outputWrapper.writeInt(superBytes.length);
         outputWrapper.write(superBytes);
         partitionSerDe.serialize(split.getPartitionValues(), outputWrapper);
+
+        ObjectOutputStream stream = new ObjectOutputStream(outputWrapper);
+        System.out.println("Scott > trying to serialize split.deltaScanTaskCore " + split.path());
+        stream.writeObject(split.deltaScanTaskCore);
+        System.out.println("Scott > serialized split.deltaScanTaskCore " + split.path());
+//        outputWrapper.close(); ???
     }
 }

--- a/flink/src/main/scala/io/delta/core/SimpleLogReplayHelper.scala
+++ b/flink/src/main/scala/io/delta/core/SimpleLogReplayHelper.scala
@@ -1,0 +1,59 @@
+package io.delta.core
+
+import scala.collection.JavaConverters._
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import org.apache.arrow.memory.RootAllocator
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import io.delta.core.arrow.ArrowParquetReader
+import io.delta.core.internal.utils.CloseableIteratorScala._
+import io.delta.core.internal.utils.CloseableIteratorScalaImpl
+import io.delta.core.json.JsonRow
+import io.delta.standalone.core.LogReplayHelper
+import io.delta.standalone.data.RowRecord
+import io.delta.standalone.expressions.Expression
+import io.delta.standalone.types.StructType
+import io.delta.standalone.utils.CloseableIterator
+import io.delta.storage.{LocalLogStore, LogStore}
+
+class SimpleLogReplayHelper(
+    val logStore: LogStore,
+    val hadoopConf: Configuration) extends LogReplayHelper {
+  def this(hadoopConf: Configuration) = this(new LocalLogStore(hadoopConf), hadoopConf)
+
+  val allocator = new RootAllocator
+
+  override def listLogFiles(dir: String): CloseableIterator[String] = {
+    logStore.listFrom(new Path(dir), hadoopConf)
+      .asScalaClosable.mapAsCloseable(_.getPath.toString).asJava
+  }
+
+  override def readParquetFile(
+      filePath: String,
+      readSchema: StructType,
+      pushdownFilters: Array[Expression]): CloseableIterator[RowRecord] = {
+    ArrowParquetReader.readAsRows(filePath, readSchema, allocator)
+  }
+
+  override def readJsonFile(
+      filePath: String,
+      readSchema: StructType): CloseableIterator[RowRecord] = {
+    val iter = logStore.read(new Path(filePath), hadoopConf)
+    new CloseableIteratorScalaImpl[String](iter.asScala, iter.close).mapAsCloseable { jsonText =>
+      SimpleLogReplayHelper.parseJson(jsonText)
+    }.asJava
+  }
+}
+
+object SimpleLogReplayHelper {
+  val mapper = new ObjectMapper
+  // mapper.setSerializationInclusion(Include.NON_ABSENT)
+  // mapper.configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false)
+
+  def parseJson(str: String): RowRecord = {
+    new JsonRow(mapper.readTree(str).asInstanceOf[ObjectNode])
+  }
+}

--- a/flink/src/main/scala/io/delta/core/SimpleLogReplayHelper.scala
+++ b/flink/src/main/scala/io/delta/core/SimpleLogReplayHelper.scala
@@ -19,10 +19,13 @@ import io.delta.standalone.types.StructType
 import io.delta.standalone.utils.CloseableIterator
 import io.delta.storage.{LocalLogStore, LogStore}
 
+// scalastyle:off println
 class SimpleLogReplayHelper(
     val logStore: LogStore,
     val hadoopConf: Configuration) extends LogReplayHelper {
   def this(hadoopConf: Configuration) = this(new LocalLogStore(hadoopConf), hadoopConf)
+
+  println("Scott > Created SimpleLogReplayHelper")
 
   val allocator = new RootAllocator
 

--- a/flink/src/main/scala/io/delta/core/SimpleScanHelper.scala
+++ b/flink/src/main/scala/io/delta/core/SimpleScanHelper.scala
@@ -1,0 +1,25 @@
+package io.delta.core
+
+import java.util.TimeZone
+
+import org.apache.arrow.memory.RootAllocator
+import org.apache.hadoop.conf.Configuration
+
+import io.delta.core.arrow.ArrowParquetReader
+import io.delta.standalone.core.DeltaScanHelper
+import io.delta.standalone.data.ColumnarRowBatch
+import io.delta.standalone.types.StructType
+import io.delta.standalone.utils.CloseableIterator
+
+class SimpleScanHelper(val hadoopConf: Configuration) extends DeltaScanHelper {
+  override def readParquetFile(
+      filePath: String,
+      readSchema: StructType,
+      timeZone: TimeZone): CloseableIterator[ColumnarRowBatch] = {
+    ArrowParquetReader.readAsColumnarBatches(filePath, readSchema, SimpleScanHelper.allocator)
+  }
+}
+
+object SimpleScanHelper {
+  val allocator = new RootAllocator
+}

--- a/flink/src/main/scala/io/delta/core/SimpleScanHelper.scala
+++ b/flink/src/main/scala/io/delta/core/SimpleScanHelper.scala
@@ -11,11 +11,16 @@ import io.delta.standalone.data.ColumnarRowBatch
 import io.delta.standalone.types.StructType
 import io.delta.standalone.utils.CloseableIterator
 
-class SimpleScanHelper(val hadoopConf: Configuration) extends DeltaScanHelper {
+// scalastyle:off println
+// NOTE: this cannot take in a val hadoopConf: Configuration, Configuration is not serializable
+class SimpleScanHelper() extends DeltaScanHelper with Serializable {
+  println("Scott > Created SimpleScanHelper")
+
   override def readParquetFile(
       filePath: String,
       readSchema: StructType,
       timeZone: TimeZone): CloseableIterator[ColumnarRowBatch] = {
+    println(s"Scott > SimpleScanHelper > readParquetFile $filePath ${readSchema.getTreeString}")
     ArrowParquetReader.readAsColumnarBatches(filePath, readSchema, SimpleScanHelper.allocator)
   }
 }

--- a/flink/src/main/scala/io/delta/core/arrow/ArrowColumnVector.java
+++ b/flink/src/main/scala/io/delta/core/arrow/ArrowColumnVector.java
@@ -1,0 +1,554 @@
+package io.delta.core.arrow;
+
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import io.delta.standalone.data.ColumnVector;
+import io.delta.standalone.data.ColumnarStruct;
+import io.delta.standalone.types.DataType;
+import org.apache.arrow.vector.*;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.holders.NullableVarCharHolder;
+
+/**
+ * A column vector backed by Apache Arrow.
+ */
+class ArrowColumnVector implements ColumnVector {
+
+    DataType type;
+    ArrowVectorAccessor accessor;
+
+    // These two are only populated and used if this column is of type struct
+    ArrowColumnVector[] childFieldVectors;
+    List<String> childFieldNames;
+
+    public ArrowColumnVector getChildVector(String fieldName) {
+        int index = childFieldNames.indexOf(fieldName);
+        if (index >= 0) {
+            return childFieldVectors[index];
+        } else {
+            throw new IllegalArgumentException(
+                    "Column vector not found for field '"  + fieldName + "'");
+        }
+    }
+
+    public ArrowColumnVector(ValueVector vector) {
+        this.type = ArrowUtils.fromArrowField(vector.getField());
+        initAccessor(vector);
+        System.out.println("" + vector.getName() + " -> " + accessor.getClass().getSimpleName());
+    }
+
+    @Override
+    public DataType getDataType() {
+        return this.type;
+    }
+
+    @Override
+    public void close() {
+        if (childFieldVectors != null) {
+            for (int i = 0; i < childFieldVectors.length; i++) {
+                childFieldVectors[i].close();
+                childFieldVectors[i] = null;
+            }
+            childFieldVectors = null;
+        }
+        accessor.close();
+    }
+
+    @Override
+    public boolean isNullAt(int rowId) {
+        return accessor.isNullAt(rowId);
+    }
+
+    @Override
+    public boolean getBoolean(int rowId) {
+        return accessor.getBoolean(rowId);
+    }
+
+    @Override
+    public byte getByte(int rowId) {
+        return accessor.getByte(rowId);
+    }
+
+    @Override
+    public short getShort(int rowId) {
+        return accessor.getShort(rowId);
+    }
+
+    @Override
+    public int getInt(int rowId) {
+        return accessor.getInt(rowId);
+    }
+
+    @Override
+    public long getLong(int rowId) {
+        return accessor.getLong(rowId);
+    }
+
+    @Override
+    public float getFloat(int rowId) {
+        return accessor.getFloat(rowId);
+    }
+
+    @Override
+    public double getDouble(int rowId) {
+        return accessor.getDouble(rowId);
+    }
+
+    @Override
+    public byte[] getBinary(int rowId) {
+        return accessor.getBinary(rowId);
+    }
+
+    @Override
+    public String getString(int rowId) {
+        return accessor.getString(rowId);
+    }
+
+    @Override
+    public ColumnarStruct getStruct(int rowId)  {
+        if (isNullAt(rowId)) return null;
+        return new ArrowColumnarStruct(this, rowId);
+    }
+
+    /*
+    @Override
+    public BigDecimal getDecimal(int rowId, int precision, int scale) {
+        if (isNullAt(rowId)) return null;
+        return accessor.getDecimal(rowId, precision, scale);
+    }
+
+    @Override
+    public ColumnarArray getArray(int rowId) {
+        if (isNullAt(rowId)) return null;
+        return accessor.getArray(rowId);
+    }
+
+    @Override
+    public ColumnarMap getMap(int rowId) {
+        if (isNullAt(rowId)) return null;
+        return accessor.getMap(rowId);
+    }
+    */
+
+    private void initAccessor(ValueVector vector) {
+        if (vector instanceof BitVector) {
+            accessor = new BooleanAccessor((BitVector) vector);
+        } else if (vector instanceof TinyIntVector) {
+            accessor = new ByteAccessor((TinyIntVector) vector);
+        } else if (vector instanceof SmallIntVector) {
+            accessor = new ShortAccessor((SmallIntVector) vector);
+        } else if (vector instanceof IntVector) {
+            accessor = new IntAccessor((IntVector) vector);
+        } else if (vector instanceof BigIntVector) {
+            accessor = new LongAccessor((BigIntVector) vector);
+        } else if (vector instanceof Float4Vector) {
+            accessor = new FloatAccessor((Float4Vector) vector);
+        } else if (vector instanceof Float8Vector) {
+            accessor = new DoubleAccessor((Float8Vector) vector);
+        } else if (vector instanceof VarCharVector) {
+            accessor = new StringAccessor((VarCharVector) vector);
+        } else if (vector instanceof DecimalVector) {
+            accessor = new DecimalAccessor((DecimalVector) vector);
+        } else if (vector instanceof VarBinaryVector) {
+            accessor = new BinaryAccessor((VarBinaryVector) vector);
+        } else if (vector instanceof DateDayVector) {
+            accessor = new DateAccessor((DateDayVector) vector);
+        } else if (vector instanceof TimeStampMicroTZVector) {
+            accessor = new TimestampAccessor((TimeStampMicroTZVector) vector);
+        } else if (vector instanceof TimeStampMicroVector) {
+            accessor = new TimestampNTZAccessor((TimeStampMicroVector) vector);
+        } /* else if (vector instanceof MapVector) {
+            MapVector mapVector = (MapVector) vector;
+            accessor = new MapAccessor(mapVector);
+        } else if (vector instanceof ListVector) {
+            ListVector listVector = (ListVector) vector;
+            accessor = new ArrayAccessor(listVector);
+        } */ else if (vector instanceof StructVector) {
+            StructVector structVector = (StructVector) vector;
+            accessor = new StructAccessor(structVector); // this should not be used
+            childFieldNames = structVector.getChildFieldNames();
+            childFieldVectors = new ArrowColumnVector[structVector.size()];
+            for (int i = 0; i < childFieldVectors.length; ++i) {
+                childFieldVectors[i] = new ArrowColumnVector(structVector.getVectorById(i));
+            }
+        } else if (vector instanceof NullVector) {
+            accessor = new NullAccessor((NullVector) vector);
+        } else if (vector instanceof IntervalYearVector) {
+            accessor = new IntervalYearAccessor((IntervalYearVector) vector);
+        } else if (vector instanceof DurationVector) {
+            accessor = new DurationAccessor((DurationVector) vector);
+        } else {
+            throw new UnsupportedOperationException(
+                "could not get accessor for " + vector.getClass().getCanonicalName());
+        }
+    }
+
+    abstract static class ArrowVectorAccessor {
+
+        final ValueVector vector;
+
+        ArrowVectorAccessor(ValueVector vector) {
+            this.vector = vector;
+        }
+
+        final boolean isNullAt(int rowId) {
+            return vector.isNull(rowId);
+        }
+
+        final int getNullCount() {
+            return vector.getNullCount();
+        }
+
+        final void close() {
+            vector.close();
+        }
+
+        boolean getBoolean(int rowId) {
+            throw new UnsupportedOperationException();
+        }
+
+        byte getByte(int rowId) {
+            throw new UnsupportedOperationException();
+        }
+
+        short getShort(int rowId) {
+            throw new UnsupportedOperationException();
+        }
+
+        int getInt(int rowId) {
+            throw new UnsupportedOperationException("in " + this.getClass().getCanonicalName());
+        }
+
+        long getLong(int rowId) {
+            throw new UnsupportedOperationException();
+        }
+
+        float getFloat(int rowId) {
+            throw new UnsupportedOperationException();
+        }
+
+        double getDouble(int rowId) {
+            throw new UnsupportedOperationException();
+        }
+
+        byte[] getBinary(int rowId) {
+            throw new UnsupportedOperationException();
+        }
+
+        String getString(int rowId) {
+            throw new UnsupportedOperationException();
+        }
+
+        BigDecimal getDecimal(int rowId, int precision, int scale) {
+            throw new UnsupportedOperationException();
+        }
+
+        /*
+        ColumnarArray getArray(int rowId) {
+            throw new UnsupportedOperationException();
+        }
+
+        ColumnarMap getMap(int rowId) {
+            throw new UnsupportedOperationException();
+        }
+        */
+    }
+
+    static class BooleanAccessor extends ArrowVectorAccessor {
+
+        private final BitVector accessor;
+
+        BooleanAccessor(BitVector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        final boolean getBoolean(int rowId) {
+            return accessor.get(rowId) == 1;
+        }
+    }
+
+    static class ByteAccessor extends ArrowVectorAccessor {
+
+        private final TinyIntVector accessor;
+
+        ByteAccessor(TinyIntVector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        final byte getByte(int rowId) {
+            return accessor.get(rowId);
+        }
+    }
+
+    static class ShortAccessor extends ArrowVectorAccessor {
+
+        private final SmallIntVector accessor;
+
+        ShortAccessor(SmallIntVector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        final short getShort(int rowId) {
+            return accessor.get(rowId);
+        }
+    }
+
+    static class IntAccessor extends ArrowVectorAccessor {
+
+        private final IntVector accessor;
+
+        IntAccessor(IntVector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        final int getInt(int rowId) {
+            return accessor.get(rowId);
+        }
+    }
+
+    static class LongAccessor extends ArrowVectorAccessor {
+
+        private final BigIntVector accessor;
+
+        LongAccessor(BigIntVector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        final long getLong(int rowId) {
+            return accessor.get(rowId);
+        }
+    }
+
+    static class FloatAccessor extends ArrowVectorAccessor {
+
+        private final Float4Vector accessor;
+
+        FloatAccessor(Float4Vector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        final float getFloat(int rowId) {
+            return accessor.get(rowId);
+        }
+    }
+
+    static class DoubleAccessor extends ArrowVectorAccessor {
+
+        private final Float8Vector accessor;
+
+        DoubleAccessor(Float8Vector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        final double getDouble(int rowId) {
+            return accessor.get(rowId);
+        }
+    }
+
+    static class BinaryAccessor extends ArrowVectorAccessor {
+
+        private final VarBinaryVector accessor;
+
+        BinaryAccessor(VarBinaryVector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        final byte[] getBinary(int rowId) {
+            if (accessor.isNull(rowId)) return null;
+            else return accessor.getObject(rowId);
+        }
+    }
+
+    static class DecimalAccessor extends ArrowVectorAccessor {
+
+        private final DecimalVector accessor;
+
+        DecimalAccessor(DecimalVector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        final BigDecimal getDecimal(int rowId, int precision, int scale) {
+            if (isNullAt(rowId)) return null;
+            return accessor.getObject(rowId);
+        }
+    }
+
+    static class StringAccessor extends ArrowVectorAccessor {
+
+        private final VarCharVector accessor;
+        private final NullableVarCharHolder stringResult = new NullableVarCharHolder();
+
+        StringAccessor(VarCharVector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        final String getString(int rowId) {
+            if (accessor.isNull(rowId)) return null;
+            else return accessor.getObject(rowId).toString();
+        }
+    }
+
+    static class DateAccessor extends ArrowVectorAccessor {
+
+        private final DateDayVector accessor;
+
+        DateAccessor(DateDayVector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        final int getInt(int rowId) {
+            return accessor.get(rowId);
+        }
+    }
+
+    static class TimestampAccessor extends ArrowVectorAccessor {
+
+        private final TimeStampMicroTZVector accessor;
+
+        TimestampAccessor(TimeStampMicroTZVector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        final long getLong(int rowId) {
+            return accessor.get(rowId);
+        }
+    }
+
+    static class TimestampNTZAccessor extends ArrowVectorAccessor {
+
+        private final TimeStampMicroVector accessor;
+
+        TimestampNTZAccessor(TimeStampMicroVector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        final long getLong(int rowId) {
+            return accessor.get(rowId);
+        }
+    }
+
+    /*
+    static class ArrayAccessor extends ArrowVectorAccessor {
+
+        private final ListVector accessor;
+        private final ArrowColumnVector arrayData;
+
+        ArrayAccessor(ListVector vector) {
+            super(vector);
+            this.accessor = vector;
+            this.arrayData = new ArrowColumnVector(vector.getDataVector());
+        }
+
+        @Override
+        final ColumnarArray getArray(int rowId) {
+            int start = accessor.getElementStartIndex(rowId);
+            int end = accessor.getElementEndIndex(rowId);
+            return new ColumnarArray(arrayData, start, end - start);
+        }
+    }
+    */
+
+    /**
+     * Any call to "get" method will throw UnsupportedOperationException.
+     *
+     * Access struct values in a ArrowColumnVector doesn't use this accessor. Instead, it uses
+     * getStruct() method defined in the parent class. Any call to "get" method in this class is a
+     * bug in the code.
+     *
+     */
+    static class StructAccessor extends ArrowVectorAccessor {
+        StructAccessor(StructVector vector) {
+            super(vector);
+        }
+    }
+
+    /*
+    static class MapAccessor extends ArrowVectorAccessor {
+        private final MapVector accessor;
+        private final ArrowColumnVector keys;
+        private final ArrowColumnVector values;
+
+        MapAccessor(MapVector vector) {
+            super(vector);
+            this.accessor = vector;
+            StructVector entries = (StructVector) vector.getDataVector();
+            this.keys = new ArrowColumnVector(entries.getChild(MapVector.KEY_NAME));
+            this.values = new ArrowColumnVector(entries.getChild(MapVector.VALUE_NAME));
+        }
+
+        @Override
+        final ColumnarMap getMap(int rowId) {
+            int index = rowId * MapVector.OFFSET_WIDTH;
+            int offset = accessor.getOffsetBuffer().getInt(index);
+            int length = accessor.getInnerValueCountAt(rowId);
+            return new ColumnarMap(keys, values, offset, length);
+        }
+    }
+
+     */
+
+    static class NullAccessor extends ArrowVectorAccessor {
+
+        NullAccessor(NullVector vector) {
+            super(vector);
+        }
+    }
+
+    static class IntervalYearAccessor extends ArrowVectorAccessor {
+
+        private final IntervalYearVector accessor;
+
+        IntervalYearAccessor(IntervalYearVector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        int getInt(int rowId) {
+            return accessor.get(rowId);
+        }
+    }
+
+    static class DurationAccessor extends ArrowVectorAccessor {
+
+        private final DurationVector accessor;
+
+        DurationAccessor(DurationVector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        final long getLong(int rowId) {
+            return DurationVector.get(accessor.getDataBuffer(), rowId);
+        }
+    }
+}

--- a/flink/src/main/scala/io/delta/core/arrow/ArrowColumnVector.java
+++ b/flink/src/main/scala/io/delta/core/arrow/ArrowColumnVector.java
@@ -3,6 +3,7 @@ package io.delta.core.arrow;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import io.delta.standalone.data.ColumnVector;
 import io.delta.standalone.data.ColumnarStruct;
@@ -53,11 +54,16 @@ class ArrowColumnVector implements ColumnVector {
             }
             childFieldVectors = null;
         }
+        System.out.println(accessor.hash + " -- Scott > accessor CLOSED");
         accessor.close();
     }
 
     @Override
     public boolean isNullAt(int rowId) {
+        System.out.println("Scott > ArrowColumnVector > isNullAt rowId " + rowId);
+        System.out.println("Scott > ArrowColumnVector > isNullAt childFieldNames " + (childFieldNames == null ? "null" : String.join(",", childFieldNames)));
+        System.out.println("Scott > ArrowColumnVector > isNullAt accessor " + accessor.toString());
+        System.out.println("Scott > ArrowColumnVector > isNullAt DataType " + type.getSimpleString());
         return accessor.isNullAt(rowId);
     }
 
@@ -188,12 +194,17 @@ class ArrowColumnVector implements ColumnVector {
     abstract static class ArrowVectorAccessor {
 
         final ValueVector vector;
+        public final long hash;
 
         ArrowVectorAccessor(ValueVector vector) {
             this.vector = vector;
+            this.hash = hashCode() % 1000;
+            System.out.println(hash + " -- Scott > ArrowVectorAccess created :: vector " + vector.toString());
         }
 
         final boolean isNullAt(int rowId) {
+            System.out.println(hash + " -- Scott > ArrowVectorAccessor > isNullAt " + rowId);
+            System.out.println(hash + " -- Scott > ArrowVectorAccessor > isNullAt > vector " + vector.toString());
             return vector.isNull(rowId);
         }
 
@@ -202,6 +213,7 @@ class ArrowColumnVector implements ColumnVector {
         }
 
         final void close() {
+            System.out.println(hash + " -- Scott > accessor closed");
             vector.close();
         }
 

--- a/flink/src/main/scala/io/delta/core/arrow/ArrowColumnarBatch.java
+++ b/flink/src/main/scala/io/delta/core/arrow/ArrowColumnarBatch.java
@@ -1,0 +1,83 @@
+package io.delta.core.arrow;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.delta.standalone.data.ColumnVector;
+import io.delta.standalone.data.ColumnarRowBatch;
+import io.delta.standalone.types.DataType;
+import io.delta.standalone.types.StructType;
+import org.apache.arrow.vector.VectorSchemaRoot;
+
+class ArrowColumnarBatch implements ColumnarRowBatch {
+
+    private VectorSchemaRoot vectorSchemaRoot;
+    private int numRows;
+    private List<ArrowColumnVector> fieldVectors;
+    private List<String> fieldNames;
+    private StructType schema;
+
+
+
+    public ArrowColumnarBatch(VectorSchemaRoot root)
+    {
+        this(
+            root,
+            root.getFieldVectors()
+                .stream()
+                .map(vector -> new ArrowColumnVector(vector))
+                .collect(Collectors.toList()),
+            root.getSchema().getFields()
+                .stream()
+                .map(field -> field.getName())
+                .collect(Collectors.toList()),
+            root.getRowCount(),
+            ArrowUtils.fromArrowSchema(root.getSchema())
+        );
+    }
+
+    public ArrowColumnarBatch(
+        VectorSchemaRoot vectorSchemaRoot,
+        List<ArrowColumnVector> fieldVectors,
+        List<String> fieldNames,
+        int numRows,
+        StructType schema) {
+        this.vectorSchemaRoot = vectorSchemaRoot;
+        this.fieldVectors = fieldVectors;
+        this.fieldNames = fieldNames;
+        this.numRows = numRows;
+        this.schema = schema;
+    }
+
+    @Override
+    public int getNumRows() {
+        return numRows;
+    }
+
+    @Override
+    public StructType schema() {
+        return schema;
+    }
+
+    @Override
+    public ColumnVector getColumnVector(String columnName) {
+        int index = fieldNames.indexOf(columnName);
+        if (index >= 0) {
+            return fieldVectors.get(index);
+        } else {
+            throw new IllegalArgumentException(
+                "Column vector not found for field '"  + columnName + "'");
+        }
+    }
+
+    @Override
+    public ColumnarRowBatch addColumnWithSingleValue(String columnName, DataType datatype, Object value) {
+        return null;
+    }
+
+    @Override
+    public void close() {
+        vectorSchemaRoot.close();
+    }
+}
+

--- a/flink/src/main/scala/io/delta/core/arrow/ArrowColumnarStruct.java
+++ b/flink/src/main/scala/io/delta/core/arrow/ArrowColumnarStruct.java
@@ -1,0 +1,74 @@
+package io.delta.core.arrow;
+
+import io.delta.standalone.data.ColumnVector;
+import io.delta.standalone.data.ColumnarStruct;
+
+class ArrowColumnarStruct implements ColumnarStruct {
+
+    ArrowColumnVector vector;
+    int rowId;
+
+    public ArrowColumnarStruct(ArrowColumnVector vector, int rowId) {
+        this.vector = vector;
+        this.rowId = rowId;
+    }
+
+    @Override
+    public boolean isNullAt(String fieldName) {
+        return getVector(fieldName).isNullAt(rowId);
+    }
+
+    @Override
+    public boolean getBoolean(String fieldName) {
+        return getVector(fieldName).getBoolean(rowId);
+    }
+
+    @Override
+    public byte getByte(String fieldName) {
+        return getVector(fieldName).getByte(rowId);
+    }
+
+    @Override
+    public short getShort(String fieldName) {
+        return getVector(fieldName).getShort(rowId);
+    }
+
+    @Override
+    public int getInt(String fieldName) {
+        return getVector(fieldName).getInt(rowId);
+    }
+
+    @Override
+    public long getLong(String fieldName) {
+        return getVector(fieldName).getLong(rowId);
+    }
+
+    @Override
+    public float getFloat(String fieldName) {
+        return getVector(fieldName).getFloat(rowId);
+    }
+
+    @Override
+    public double getDouble(String fieldName) {
+        return getVector(fieldName).getDouble(rowId);
+    }
+
+    @Override
+    public byte[] getBinary(String fieldName) {
+        return getVector(fieldName).getBinary(rowId);
+    }
+
+    @Override
+    public ColumnarStruct getStruct(String fieldName) {
+        return getVector(fieldName).getStruct(rowId);
+    }
+
+    @Override
+    public String getString(String fieldName) {
+        return getVector(fieldName).getString(rowId);
+    }
+
+    private ColumnVector getVector(String fieldName) {
+        return vector.getChildVector(fieldName);
+    }
+}

--- a/flink/src/main/scala/io/delta/core/arrow/ArrowParquetReader.scala
+++ b/flink/src/main/scala/io/delta/core/arrow/ArrowParquetReader.scala
@@ -1,0 +1,106 @@
+package io.delta.core.arrow
+
+import java.util.Optional
+
+import org.apache.arrow.dataset.file.{FileFormat, FileSystemDatasetFactory}
+import org.apache.arrow.dataset.jni.NativeMemoryPool
+import org.apache.arrow.dataset.scanner.{ScanOptions, Scanner}
+import org.apache.arrow.dataset.source.{Dataset, DatasetFactory}
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.ipc.ArrowReader
+
+import io.delta.standalone.data.{ColumnarRowBatch, RowRecord}
+import io.delta.standalone.types.StructType
+import io.delta.standalone.utils.CloseableIterator
+
+object ArrowParquetReader {
+
+  def readAsColumnarBatches(
+    filePath: String,
+    readSchema: StructType,
+    allocator: RootAllocator): CloseableIterator[ColumnarRowBatch] = {
+
+    val readColumnNames = readSchema.getFields.map(_.getName)
+    val options = new ScanOptions(32768, Optional.of(readColumnNames))
+
+    var datasetFactory: DatasetFactory = null
+    var dataset: Dataset = null
+    var scanner: Scanner = null
+    var reader: ArrowReader = null
+
+    def closeAll(): Unit = {
+      if (scanner != null) scanner.close()
+      if (dataset != null) dataset.close()
+      if (datasetFactory != null) datasetFactory.close()
+      if (reader != null) reader.close()
+    }
+
+    try {
+      datasetFactory = new FileSystemDatasetFactory(
+        allocator, NativeMemoryPool.getDefault, FileFormat.PARQUET, filePath)
+      dataset = datasetFactory.finish()
+      scanner = dataset.newScan(options)
+      reader = scanner.scanBatches()
+
+      new CloseableIterator[ColumnarRowBatch] {
+        var isNextBatchLoaded = false
+        var nextBatch: ArrowColumnarBatch = null
+        var closed = false
+
+        override def hasNext: Boolean = {
+          if (closed) return false
+
+          if (!isNextBatchLoaded) {
+            isNextBatchLoaded = reader.loadNextBatch()
+            if (isNextBatchLoaded) {
+              if (nextBatch != null) { nextBatch.close() }
+              nextBatch = new ArrowColumnarBatch(reader.getVectorSchemaRoot())
+            } else {
+              close()
+            }
+          }
+          isNextBatchLoaded
+        }
+
+        override def next(): ColumnarRowBatch = {
+          if (closed) throw new IllegalStateException("already closed")
+          if (!isNextBatchLoaded) throw new IllegalStateException("next batch has not been loaded")
+          isNextBatchLoaded = false
+          nextBatch
+        }
+
+        override def close(): Unit = {
+          if (!closed) {
+            closeAll()
+            if (nextBatch != null) { nextBatch.close() }
+            isNextBatchLoaded = false
+            closed = true
+          }
+        }
+      }
+    } catch {
+      case e: Exception =>
+        e.printStackTrace()
+        closeAll()
+        throw e
+    }
+  }
+
+  def readAsRows(
+    filePath: String,
+    readSchema: StructType,
+    allocator: RootAllocator
+  ): CloseableIterator[RowRecord] = {
+    import io.delta.core.internal.utils.CloseableIteratorScala._
+
+    readAsColumnarBatches(filePath, readSchema, allocator)
+      .asScalaCloseable
+      .flatMapAsCloseable { batch =>
+        println(s"batch = $batch")
+        val rows = batch.getRows
+        println(s"rows = $rows")
+        val x = rows.asScalaCloseable
+        x
+      }.asJava
+  }
+}

--- a/flink/src/main/scala/io/delta/core/arrow/ArrowParquetReader.scala
+++ b/flink/src/main/scala/io/delta/core/arrow/ArrowParquetReader.scala
@@ -19,6 +19,7 @@ object ArrowParquetReader {
     filePath: String,
     readSchema: StructType,
     allocator: RootAllocator): CloseableIterator[ColumnarRowBatch] = {
+    println("Scott > ArrowParquetReader > readAsColumnarBatches")
 
     val readColumnNames = readSchema.getFields.map(_.getName)
     val options = new ScanOptions(32768, Optional.of(readColumnNames))

--- a/flink/src/main/scala/io/delta/core/arrow/ArrowUtils.scala
+++ b/flink/src/main/scala/io/delta/core/arrow/ArrowUtils.scala
@@ -1,0 +1,128 @@
+package io.delta.core.arrow
+
+import scala.collection.JavaConverters._
+
+import org.apache.arrow.vector.complex.MapVector
+import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
+import org.apache.arrow.vector.types.{DateUnit, FloatingPointPrecision, TimeUnit}
+
+import io.delta.standalone.types._
+
+
+object ArrowUtils {
+
+  /** Maps data type from Spark to Arrow. NOTE: timeZoneId required for TimestampTypes */
+  def toArrowType(dt: DataType, timeZoneId: String): ArrowType = dt match {
+    case _: BooleanType => ArrowType.Bool.INSTANCE
+    case _: ByteType => new ArrowType.Int(8, true)
+    case _: ShortType => new ArrowType.Int(8 * 2, true)
+    case _: IntegerType => new ArrowType.Int(8 * 4, true)
+    case _: LongType => new ArrowType.Int(8 * 8, true)
+    case _: FloatType => new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)
+    case _: DoubleType => new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)
+    case _: StringType => ArrowType.Utf8.INSTANCE
+    case _: BinaryType => ArrowType.Binary.INSTANCE
+    case _: DateType => new ArrowType.Date(DateUnit.DAY)
+    case _: TimestampType if timeZoneId == null =>
+      throw new IllegalStateException("Missing timezoneId where it is mandatory.")
+    case _: TimestampType => new ArrowType.Timestamp(TimeUnit.MICROSECOND, timeZoneId)
+    case _: NullType => ArrowType.Null.INSTANCE
+    case d: DecimalType => new ArrowType.Decimal(d.getPrecision, d.getScale)
+    case _: TimestampType => new ArrowType.Timestamp(TimeUnit.MICROSECOND, null)
+    // case _: YearMonthIntervalType => new ArrowType.Interval(IntervalUnit.YEAR_MONTH)
+    // case _: DayTimeIntervalType => new ArrowType.Duration(TimeUnit.MICROSECOND)
+    case _ =>
+      throw new IllegalArgumentException(s"could not convert core data type $dt to arrow type")
+  }
+
+  def fromArrowType(dt: ArrowType): DataType = dt match {
+    case ArrowType.Bool.INSTANCE => new BooleanType
+    case int: ArrowType.Int if int.getIsSigned && int.getBitWidth == 8 => new ByteType
+    case int: ArrowType.Int if int.getIsSigned && int.getBitWidth == 8 * 2 => new ShortType
+    case int: ArrowType.Int if int.getIsSigned && int.getBitWidth == 8 * 4 => new IntegerType
+    case int: ArrowType.Int if int.getIsSigned && int.getBitWidth == 8 * 8 => new LongType
+    case float: ArrowType.FloatingPoint
+      if float.getPrecision() == FloatingPointPrecision.SINGLE => new FloatType
+    case float: ArrowType.FloatingPoint
+      if float.getPrecision() == FloatingPointPrecision.DOUBLE => new DoubleType
+    case ArrowType.Utf8.INSTANCE => new StringType
+    case ArrowType.Binary.INSTANCE => new BinaryType
+    case ts: ArrowType.Timestamp if ts.getUnit == TimeUnit.MICROSECOND => new TimestampType
+    case ArrowType.Null.INSTANCE => new NullType
+    case date: ArrowType.Date if date.getUnit == DateUnit.DAY => new DateType
+    case d: ArrowType.Decimal => new DecimalType(d.getPrecision, d.getScale)
+    case ts: ArrowType.Timestamp if ts.getUnit == TimeUnit.MICROSECOND && ts.getTimezone == null =>
+      new TimestampType()
+    /*
+    case yi: ArrowType.Interval if yi.getUnit == IntervalUnit.YEAR_MONTH => YearMonthIntervalType()
+    case di: ArrowType.Duration if di.getUnit == TimeUnit.MICROSECOND => DayTimeIntervalType()
+    */
+    case _ =>
+      throw new IllegalArgumentException(s"could not convert arrow type $dt to core data type")
+  }
+
+  /** Maps field from Spark to Arrow. NOTE: timeZoneId required for TimestampType */
+  def toArrowField(
+    name: String, dt: DataType, nullable: Boolean, timeZoneId: String): Field = {
+    dt match {
+      case a: ArrayType =>
+        val fieldType = new FieldType(nullable, ArrowType.List.INSTANCE, null)
+        new Field(name, fieldType,
+          Seq(toArrowField("element", a.getElementType, a.containsNull(), timeZoneId)).asJava)
+      case s: StructType =>
+        val fieldType = new FieldType(nullable, ArrowType.Struct.INSTANCE, null)
+        new Field(name, fieldType,
+          s.getFields.map { field =>
+            toArrowField(field.getName, field.getDataType, field.isNullable, timeZoneId)
+          }.toSeq.asJava)
+      case m: MapType =>
+        val mapType = new FieldType(nullable, new ArrowType.Map(false), null)
+        // Note: Map Type struct can not be null, Struct Type key field can not be null
+        new Field(name, mapType,
+          Seq(toArrowField(MapVector.DATA_VECTOR_NAME,
+            new StructType()
+              .add(MapVector.KEY_NAME, m.getKeyType, false)
+              .add(MapVector.VALUE_NAME, m.getValueType, m.valueContainsNull()),
+            nullable = false,
+            timeZoneId)).asJava)
+      case dataType =>
+        val fieldType = new FieldType(nullable, toArrowType(dataType, timeZoneId), null)
+        new Field(name, fieldType, Seq.empty[Field].asJava)
+    }
+  }
+
+  def fromArrowField(field: Field): DataType = {
+    field.getType match {
+      case _: ArrowType.Map =>
+        val elementField = field.getChildren.get(0)
+        val keyType = fromArrowField(elementField.getChildren.get(0))
+        val valueType = fromArrowField(elementField.getChildren.get(1))
+        new MapType(keyType, valueType, elementField.getChildren.get(1).isNullable)
+      case ArrowType.List.INSTANCE =>
+        val elementField = field.getChildren().get(0)
+        val elementType = fromArrowField(elementField)
+        new ArrayType(elementType, elementField.isNullable)
+      case ArrowType.Struct.INSTANCE =>
+        val fields = field.getChildren().asScala.map { child =>
+          val dt = fromArrowField(child)
+          new StructField(child.getName, dt, child.isNullable)
+        }
+        new StructType(fields.toArray)
+      case arrowType => fromArrowType(arrowType)
+    }
+  }
+
+  /** Maps schema from Spark to Arrow. NOTE: timeZoneId required for TimestampType in StructType */
+  def toArrowSchema(schema: StructType, timeZoneId: String): Schema = {
+    new Schema(schema.getFields.map { field =>
+      toArrowField(field.getName, field.getDataType, field.isNullable, timeZoneId)
+    }.toIterable.asJava)
+  }
+
+  def fromArrowSchema(schema: Schema): StructType = {
+    new StructType(schema.getFields.asScala.map { field =>
+      val dt = fromArrowField(field)
+      new StructField(field.getName, dt, field.isNullable)
+    }.toArray)
+  }
+}

--- a/flink/src/main/scala/io/delta/core/json/JsonRow.scala
+++ b/flink/src/main/scala/io/delta/core/json/JsonRow.scala
@@ -1,0 +1,98 @@
+package io.delta.core.json
+
+import java.sql.{Date, Timestamp}
+import java.util
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.{ArrayNode, ObjectNode}
+
+import io.delta.standalone.data.RowRecord
+import io.delta.standalone.types.StructType
+
+class JsonRow(rootNode: ObjectNode) extends RowRecord {
+  override def getSchema: StructType = {
+    throw new UnsupportedOperationException("not supported")
+  }
+
+  override def getLength: Int = {
+    throw new UnsupportedOperationException("not supported")
+  }
+
+  override def isNullAt(fieldName: String): Boolean = !rootNode.hasNonNull(fieldName)
+
+  override def getInt(fieldName: String): Int = rootNode.get(fieldName).intValue()
+
+  override def getLong(fieldName: String): Long = rootNode.get(fieldName).longValue()
+
+  override def getBoolean(fieldName: String): Boolean = rootNode.get(fieldName).booleanValue()
+
+  override def getDouble(fieldName: String): Double = rootNode.get(fieldName).doubleValue()
+
+  override def getString(fieldName: String): String = rootNode.get(fieldName).textValue()
+
+  override def getRecord(fieldName: String): RowRecord = {
+    if (!rootNode.get(fieldName).isObject) throw new ClassCastException()
+    new JsonRow(rootNode.get(fieldName).asInstanceOf[ObjectNode])
+  }
+
+  override def getList[T](fieldName: String): util.List[T] = {
+    if (!rootNode.get(fieldName).isArray) throw new ClassCastException()
+    val list = new ArrayBuffer[Any]()
+    rootNode.get(fieldName).asInstanceOf[ArrayNode].elements().asScala.foreach { node =>
+      list += getValue(node)
+    }
+    list.asJava.asInstanceOf[util.List[T]]
+  }
+
+  override def getMap[K, V](fieldName: String): util.Map[K, V] = {
+    val node = rootNode.get(fieldName)
+    if (!node.isObject) throw new ClassCastException()
+
+    val objectNode = node.asInstanceOf[ObjectNode]
+    val keyValuePairs = objectNode.fields().asScala.map { entry =>
+      entry.getKey -> getValue(entry.getValue)
+    }
+    if (keyValuePairs.isEmpty) return Map.empty[K, V].asJava // Map.of didn't compile :shrug:
+    keyValuePairs.toMap.asJava.asInstanceOf[util.Map[K, V]]
+  }
+
+  override def getBigDecimal(fieldName: String): java.math.BigDecimal = {
+    throw new UnsupportedOperationException("not supported")
+  }
+
+  override def getDate(fieldName: String): Date = {
+    throw new UnsupportedOperationException("not supported")
+  }
+
+  override def getTimestamp(fieldName: String): Timestamp = {
+    throw new UnsupportedOperationException("not supported")
+  }
+
+  override def getBinary(fieldName: String): Array[Byte] = {
+    throw new UnsupportedOperationException("not supported")
+  }
+
+  override def getByte(fieldName: String): Byte = {
+    throw new UnsupportedOperationException("not supported")
+  }
+
+  override def getShort(fieldName: String): Short = {
+    rootNode.get(fieldName).shortValue()
+  }
+
+  override def getFloat(fieldName: String): Float = {
+    throw new UnsupportedOperationException("not supported")
+  }
+
+  private def getValue(node: JsonNode): Any = {
+    if (node.isBoolean) node.booleanValue()
+    else if (node.isInt) node.intValue()
+    else if (node.isDouble) node.doubleValue()
+    else if (node.isTextual) node.textValue()
+    else if (node.isObject) new JsonRow(node.asInstanceOf[ObjectNode])
+    else throw new UnsupportedOperationException(s"not supported handling $node")
+  }
+}

--- a/flink/src/test/java/io/delta/flink/source/SimpleDeltaCoreSourceSuite.java
+++ b/flink/src/test/java/io/delta/flink/source/SimpleDeltaCoreSourceSuite.java
@@ -30,7 +30,7 @@ public class SimpleDeltaCoreSourceSuite extends TestLogger {
         DeltaSource<RowData> source = DeltaSource.forBoundedRowData(path, hadoopConf).build();
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setParallelism(4);
+        env.setParallelism(1);
         env.setRuntimeMode(RuntimeExecutionMode.AUTOMATIC);
         env.setRestartStrategy(RestartStrategies.fixedDelayRestart(5, 1000));
 

--- a/flink/src/test/java/io/delta/flink/source/SimpleDeltaCoreSourceSuite.java
+++ b/flink/src/test/java/io/delta/flink/source/SimpleDeltaCoreSourceSuite.java
@@ -32,8 +32,11 @@ public class SimpleDeltaCoreSourceSuite extends TestLogger {
 
         ClientAndIterator<RowData> client = DataStreamUtils.collectWithClient(stream, "Bounded Delta Source Test");
 
+        int count = 0;
         while (client.iterator.hasNext()) {
             System.out.println(client.iterator.next());
+            count++;
         }
+        System.out.println("COUNT: " + count);
     }
 }

--- a/flink/src/test/java/io/delta/flink/source/SimpleDeltaCoreSourceSuite.java
+++ b/flink/src/test/java/io/delta/flink/source/SimpleDeltaCoreSourceSuite.java
@@ -18,7 +18,13 @@ import org.junit.Test;
 public class SimpleDeltaCoreSourceSuite extends TestLogger {
     @Test
     public void test00() throws Exception {
-        // first, locally write to /tmp/
+        /*
+        path = "/tmp/delta_core_flink_test_tables/table_000"
+        for i in range(8):
+            low = i*100
+            high = low+100
+            spark.range(low, high).write.format("delta").mode("append").save(path)
+         */
         final Configuration hadoopConf = new Configuration();
         final Path path = Path.fromLocalFile(new File("/tmp/delta_core_flink_test_tables/table_000"));
         DeltaSource<RowData> source = DeltaSource.forBoundedRowData(path, hadoopConf).build();

--- a/flink/src/test/java/io/delta/flink/source/SimpleDeltaCoreSourceSuite.java
+++ b/flink/src/test/java/io/delta/flink/source/SimpleDeltaCoreSourceSuite.java
@@ -1,0 +1,39 @@
+package io.delta.flink.source;
+
+import java.io.File;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamUtils;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.collect.ClientAndIterator;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.TestLogger;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+
+public class SimpleDeltaCoreSourceSuite extends TestLogger {
+    @Test
+    public void test00() throws Exception {
+        // first, locally write to /tmp/
+        final Configuration hadoopConf = new Configuration();
+        final Path path = Path.fromLocalFile(new File("/tmp/delta_core_flink_test_tables/table_000"));
+        DeltaSource<RowData> source = DeltaSource.forBoundedRowData(path, hadoopConf).build();
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(4);
+        env.setRuntimeMode(RuntimeExecutionMode.AUTOMATIC);
+        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(5, 1000));
+
+        DataStream<RowData> stream = env.fromSource(source, WatermarkStrategy.noWatermarks(), "delta-source");
+
+        ClientAndIterator<RowData> client = DataStreamUtils.collectWithClient(stream, "Bounded Delta Source Test");
+
+        while (client.iterator.hasNext()) {
+            System.out.println(client.iterator.next());
+        }
+    }
+}


### PR DESCRIPTION
Test using `build/sbt 'flink/testOnly *SimpleDeltaCoreSourceSuite'`

In summary
- the file format `DeltaBulkFormat` knows that it is only for split type `DeltaSourceSplit`
- the `DeltaSourceSplit` has-a `DeltaScanTaskCore`
- these splits are sent from the SplitEnumerator to each SourceReader. these splits must be serializable. so all the StructType, StructField, scanHelper etc etc had to be serializable.
- the SourceReader asks the file format to create a reader. `RowDataFormat` (which extends `DeltaBulkFormat`) gives it a `DeltaCoreRowDataReader`. When asked to give the SourceReader this concrete reader, the file format gets a reference to the split
- so, our `DeltaCoreRowDataReader` just uses the split's underlying `DeltaScanTaskCore` to call `getDataAsRows`

Anyways, `DeltaCoreRowDataReader` is broken. Infinite loop.