### PR TITLE
Skeleton for flink vectorized parquet scan helper

### DIFF
--- a/core/src/main/java/io/delta/standalone/core/DeltaScanTaskCore.java
+++ b/core/src/main/java/io/delta/standalone/core/DeltaScanTaskCore.java
@@ -8,6 +8,9 @@ import io.delta.standalone.types.StructType;
 import io.delta.standalone.utils.CloseableIterator;
 
 public interface DeltaScanTaskCore extends Serializable {
+
+    void injectScanHelper(DeltaScanHelper helper);
+
     CloseableIterator<RowBatch> getDataAsRows();
 
     String getFilePath();

--- a/core/src/main/scala/io/delta/core/internal/DeltaScanTaskCoreImpl.scala
+++ b/core/src/main/scala/io/delta/core/internal/DeltaScanTaskCoreImpl.scala
@@ -17,7 +17,12 @@ class DeltaScanTaskCoreImpl(
     filePartitionValues: Map[String, String],
     schema: StructType,
     readTimeZone: TimeZone,
-    scanHelper: DeltaScanHelper) extends DeltaScanTaskCore {
+    var scanHelper: DeltaScanHelper) extends DeltaScanTaskCore {
+
+  override def injectScanHelper(helper: DeltaScanHelper): Unit = {
+    this.scanHelper = helper
+  }
+
   override def getFilePath: String = filePath
 
   override def getSchema: StructType = schema

--- a/flink/src/main/java/io/delta/flink/source/internal/builder/RowDataFormat.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/builder/RowDataFormat.java
@@ -3,6 +3,7 @@ package io.delta.flink.source.internal.builder;
 import java.io.IOException;
 
 import io.delta.flink.source.internal.core.DeltaCoreRowDataReader;
+import io.delta.flink.source.internal.core.ParquetVectorizedReaderScanHelper;
 import io.delta.flink.source.internal.state.DeltaSourceSplit;
 import javax.annotation.Nullable;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -11,6 +12,7 @@ import org.apache.flink.formats.parquet.ParquetColumnarRowInputFormat;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.hadoop.ParquetReader;
 
 /**
  * Implementation of {@link DeltaBulkFormat} for {@link RowData} type.
@@ -32,8 +34,11 @@ public class RowDataFormat implements DeltaBulkFormat<RowData> {
             org.apache.flink.configuration.Configuration configuration,
             DeltaSourceSplit deltaSourceSplit) throws IOException {
         // System.out.println("Scott > RowDataFormat :: createReader, split " + deltaSourceSplit.path());
+        BulkFormat.Reader<RowData> reader = this.decoratedInputFormat.createReader(configuration, deltaSourceSplit);
+
+        deltaSourceSplit.deltaScanTaskCore.injectScanHelper(new ParquetVectorizedReaderScanHelper(reader));
+
         return new DeltaCoreRowDataReader(deltaSourceSplit.deltaScanTaskCore);
-//        return this.decoratedInputFormat.createReader(configuration, deltaSourceSplit);
     }
 
     @Override

--- a/flink/src/main/java/io/delta/flink/source/internal/core/ParquetVectorizedReaderScanHelper.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/core/ParquetVectorizedReaderScanHelper.java
@@ -1,0 +1,88 @@
+package io.delta.flink.source.internal.core;
+
+import java.io.IOException;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.TimeZone;
+
+import io.delta.standalone.core.DeltaScanHelper;
+import io.delta.standalone.data.ColumnarRowBatch;
+import io.delta.standalone.types.StructType;
+import io.delta.standalone.utils.CloseableIterator;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.util.RecordAndPosition;
+import org.apache.flink.table.data.RowData;
+
+public class ParquetVectorizedReaderScanHelper implements DeltaScanHelper {
+
+    private final BulkFormat.Reader<RowData> parquetVectorizedReader;
+
+    public ParquetVectorizedReaderScanHelper(BulkFormat.Reader<RowData> parquetVectorizedReader) {
+        this.parquetVectorizedReader = parquetVectorizedReader;
+    }
+
+
+    @Override
+    public CloseableIterator<ColumnarRowBatch> readParquetFile(String filePath, StructType readSchema, TimeZone timeZone) {
+        return new CloseableIterator<ColumnarRowBatch>() {
+            private BulkFormat.RecordIterator<RowData> iter = null;
+
+            // EMPTY -> unknown if there is or isn't a next element
+            // NON-EMPTY -> there is a next element
+            // null -> there is no next element
+            private Optional<RowData> nextRowData = Optional.empty();
+
+
+            {
+                try {
+                    iter = parquetVectorizedReader.readBatch();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    throw new RuntimeException("could not read batch");
+                }
+            }
+
+            @Override
+            public void close() throws IOException {
+
+            }
+
+            @Override
+            public boolean hasNext() {
+                if (nextRowData == null) return false;
+                if (nextRowData.isPresent()) return true;
+
+                // We aren't sure if there is or isn't a next element
+
+                fetchNext();
+
+                // Now we are sure, either nextRowData is null or it contains the next element
+
+                return nextRowData != null;
+            }
+
+            @Override
+            public ColumnarRowBatch next() {
+                if (!hasNext()) throw new NoSuchElementException();
+                RowData rowData = nextRowData.get();
+
+                // TODO: fundamental mismatch here between the underlying reader ... which reads
+                // rows in BATCH but then provides an individual-per-row API .... and this API
+                // ... which exposes a RowBatch
+                // TODO convert rowData to ColumnarRowBatch
+
+                return null;
+            }
+
+            private void fetchNext() {
+                RecordAndPosition<RowData> next = iter.next();
+
+                if (next == null) {
+                    nextRowData = null;
+                } else {
+                    nextRowData = Optional.of(next.getRecord());
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
To summarize:
- the JobManager uses the `DeltaCoreSnapshot` to get a `Scan` and to get the `Task`s
- per flink logic, the JobManager must send `Split`s to the different readers. We created our own custom `DeltaSourceSplit` for this, and it contains a `Task`.
- In the previous hack, the `RowDataFormat`, which is responsible for creating the underlying parquet reader, just used the underlying task to get the data as rows ... using the default scan helper
- Here, instead, we want to use flink's `ParquetColumnarRowInputFormat::createReader` to create a `ParquetReader` and use that to implement our own custom scan helper that does BATCH / VECTORIZED reads
- these vectorized reads are abstracted away from the API that the `ParquetReader` exposes, which is just an `RecordIterator<RowData> readBatch`.
- however, currently in this branch `ScanHelper` must implement `CloseableIterator<ColumnarRowBatch> readParquetFile` ... so we want to expose ColumnarRowBatch ...... but all we have access to is `readBatch` which only exposes individual rows .... all the batch stuff is done behind the API in the implementation